### PR TITLE
Add: reusable Input component and use in SigninForm

### DIFF
--- a/src/components/auth/sigin-form.tsx
+++ b/src/components/auth/sigin-form.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { faHeart } from "@fortawesome/free-regular-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { Input } from "../ui/input";
 
 export const SigninForm = () => {
   const router = useRouter();
@@ -16,17 +15,16 @@ export const SigninForm = () => {
 
   return (
     <>
-      <input
-        type="email"
+      <Input
         placeholder="Type your email"
         value={emailField}
-        onChange={(e) => setEmailField(e.target.value)}
+        onChange={(t) => setEmailField(t)}
       />
-      <input
-        type="password"
+      <Input
         placeholder="Type your password"
         value={passwordField}
-        onChange={(e) => setPasswordField(e.target.value)}
+        onChange={(t) => setPasswordField(t)}
+        password
       />
       <button type="submit" onClick={handleSignin}>
         Sign In

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { faEye, faEyeSlash } from "@fortawesome/free-regular-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useState } from "react";
+
+type Props = {
+  placeholder: string;
+  value?: string;
+  filled?: boolean;
+  icon?: IconDefinition;
+  password?: boolean;
+  onChange?: (newValue: string) => void;
+};
+
+export const Input = ({
+  placeholder,
+  value,
+  password,
+  icon,
+  filled,
+  onChange,
+}: Props) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div
+      className={`has-[:focus]:border-white flex items-center h-14 rounded-3xl border-2 border-gray-700 ${
+        filled && "bg-gray-700"
+      }`}
+    >
+      {icon && (
+        <FontAwesomeIcon icon={icon} className="ml-4 size-6 text-gray-500" />
+      )}
+      <input
+        className="flex-1 outline-none bg-transparent h-full px-4"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange && onChange(e.target.value)}
+        type={password && showPassword ? "text" : "password"}
+      />
+      {password && (
+        <FontAwesomeIcon
+          onClick={() => setShowPassword(!showPassword)}
+          icon={showPassword ? faEye : faEyeSlash}
+          className="cursor-pointer mr-4 size-6 text-gray-500"
+        />
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Introduce a new reusable Input component (src/components/ui/input.tsx) that supports icons, filled state, controlled value, and a password visibility toggle. Replace native <input> elements in SigninForm with the new Input, update onChange handlers to pass string values, and remove unused FontAwesome imports from the form. This centralizes input behavior and UI for reuse across the app.

closes #6 