### PR TITLE
Add: Button component and use in SigninForm

### DIFF
--- a/src/components/auth/sigin-form.tsx
+++ b/src/components/auth/sigin-form.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Input } from "../ui/input";
+import { Button } from "../ui/button";
 
 export const SigninForm = () => {
   const router = useRouter();
@@ -26,9 +27,7 @@ export const SigninForm = () => {
         onChange={(t) => setPasswordField(t)}
         password
       />
-      <button type="submit" onClick={handleSignin}>
-        Sign In
-      </button>
+      <Button label="Sign In" onClick={handleSignin} size="lg" />
     </>
   );
 };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,16 @@
+type Props = {
+  label: string;
+  onClick?: () => void;
+  size: "sm" | "md" | "lg";
+};
+
+export const Button = ({ label, onClick, size }: Props) => {
+  return (
+    <div
+      onClick={onClick}
+      className={`flex justify-center items-center cursor-pointer bg-white text-black font-bold rounded-3xl ${size === "sm" ? "h-7 text-xs" : size === "md" ? "h-10 text-md" : size === "lg" ? "h-14 text-lg" : "h-14 text-lg"}`}
+    >
+      {label}
+    </div>
+  );
+};


### PR DESCRIPTION
Introduce a reusable Button component (label, onClick, size) at src/components/ui/button.tsx and replace the native <button> in src/components/auth/sigin-form.tsx with this Button. The Button exposes props for label, click handler and three size variants (sm, md, lg) and applies centered styling and size-based classes to standardize the sign-in UI.

closes #7 