### PR TITLE
Add: sidebar Search, Trending & Recommendations

### DIFF
--- a/src/app/(ui)/layout.tsx
+++ b/src/app/(ui)/layout.tsx
@@ -2,6 +2,9 @@ import { NavItem } from "@/components/nav/nav-item";
 import { NavLogout } from "@/components/nav/nav-logout";
 import { NavMyProfile } from "@/components/nav/nav-myprofile";
 import { Logo } from "@/components/ui/logo";
+import { RecommendationArea } from "@/components/ui/recommendation-area";
+import { SearchInput } from "@/components/ui/search-input";
+import { TrendingArea } from "@/components/ui/trending-area";
 import { faHouse, faUser } from "@fortawesome/free-regular-svg-icons";
 
 type Props = {
@@ -26,7 +29,9 @@ export default function Layout({ children }: Props) {
       </section>
       <section className="flex-1 max-w-lg">{children}</section>
       <aside className="hidden lg:flex flex-col gap-6 sticky top-0 h-fit w-96 px-8 py-6 border-l-2 border-gray-900">
-        Right
+        <SearchInput hideOnSearch/>
+        <TrendingArea />
+        <RecommendationArea />
       </aside>
     </main>
   );

--- a/src/components/nav/nav-myprofile.tsx
+++ b/src/components/nav/nav-myprofile.tsx
@@ -13,6 +13,7 @@ export const NavMyProfile = () => {
             width={40}
             height={40}
             className="size-full object-cover"
+            loading="eager"
           />
         </Link>
       </div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,6 +12,7 @@ type Props = {
   icon?: IconDefinition;
   password?: boolean;
   onChange?: (newValue: string) => void;
+  onEnter?: () => void;
 };
 
 export const Input = ({
@@ -21,8 +22,15 @@ export const Input = ({
   icon,
   filled,
   onChange,
+  onEnter,
 }: Props) => {
   const [showPassword, setShowPassword] = useState(false);
+
+  const handleKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" && onEnter) {
+      onEnter();
+    }
+  };
 
   return (
     <div
@@ -38,7 +46,8 @@ export const Input = ({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange && onChange(e.target.value)}
-        type={password && showPassword ? "text" : "password"}
+        onKeyUp={handleKeyUp}
+        type={password && !showPassword ? "password" : "text"}
       />
       {password && (
         <FontAwesomeIcon

--- a/src/components/ui/recommendation-area.tsx
+++ b/src/components/ui/recommendation-area.tsx
@@ -1,0 +1,14 @@
+import { user } from "@/data/user";
+import { RecommendationItem, RecommendationItemSkeleton } from "./recommendation-item";
+
+export const RecommendationArea = () => {
+  return (
+    <div className="bg-gray-700 rounded-3xl">
+      <h2 className="text-xl p-6">Who follow</h2>
+      <div className="flex flex-col gap-4 p-6 pt-0">
+        <RecommendationItem user={user} />
+        <RecommendationItemSkeleton />
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/recommendation-item.tsx
+++ b/src/components/ui/recommendation-item.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { User } from "@/types/user";
+import Image from "next/image";
+import Link from "next/link";
+import { Button } from "./button";
+import { useState } from "react";
+
+type Props = {
+  user: User;
+};
+
+export const RecommendationItem = ({ user }: Props) => {
+  const [following, setFollowing] = useState(false);
+
+  const handleFollowButton = () => {
+    setFollowing(true);
+  };
+
+  const handleUnFollowButton = () => {
+    setFollowing(false);
+  };
+
+  return (
+    <div className="flex items-center">
+      <div className="size-10 mr-2 rounded-full overflow-hidden">
+        <Link href={`/profile/${user.slug}`}>
+          <Image
+            src={user.avatar}
+            alt={user.name}
+            width={40}
+            height={40}
+            className="size-full object-cover"
+            loading="eager"
+          />
+        </Link>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <Link href={`/${user.slug}`} className="block truncate">
+          {user.name}
+        </Link>
+        <div className="truncate text-sm text-gray-400">@{user.slug}</div>
+      </div>
+      <div className="pl-2 w-20">
+        {!following ? (
+          <Button label="Follow" onClick={handleFollowButton} size="sm" />
+        ) : (
+          <Button label="Unfollow" onClick={handleUnFollowButton} size="sm" />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const RecommendationItemSkeleton = () => {
+  return (
+    <div className="animate-pulse flex items-center">
+      <div className="size-10 mr-2 rounded-full bg-gray-600"></div>
+      <div className=" flex-1 flex flex-col gap-1">
+        <div className="h-4 w-3/4 bg-gray-600 rounded"></div>
+        <div className="h-3 w-1/4 bg-gray-600 rounded"></div>
+      </div>
+      <div className="pl-2 w-20">
+        <div className="h-7 bg-gray-600 rounded-full"></div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
+import { Input } from "./input";
+import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+type Props = {
+  defaultValue?: string;
+  hideOnSearch?: boolean;
+};
+
+export const SearchInput = ({ defaultValue, hideOnSearch }: Props) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [searchInput, setSearchInput] = useState(defaultValue ?? "");
+
+  const handleSearchEnter = () => {
+    if (searchInput) {
+      router.push("/search?q=" + encodeURIComponent(searchInput));
+    }
+  };
+
+  if (hideOnSearch && pathname === "/search") return null;
+
+  return (
+    <Input
+      placeholder="Search"
+      icon={faMagnifyingGlass}
+      filled
+      value={searchInput}
+      onChange={(t) => setSearchInput(t)}
+      onEnter={handleSearchEnter}
+    />
+  );
+};

--- a/src/components/ui/trending-area.tsx
+++ b/src/components/ui/trending-area.tsx
@@ -1,0 +1,15 @@
+import { TrendingItem, TrendingItemSkeleton } from "./trending-item";
+
+export const TrendingArea = () => {
+  return (
+    <div className="bg-gray-700 rounded-3xl">
+      <h2 className="text-xl p-6">What is happening</h2>
+      <div className="flex flex-col gap-4 p-6 pt-0">
+        <TrendingItem label="#Teste" count={1234}/>
+        <TrendingItem label="#Teste" count={1234}/>
+        <TrendingItemSkeleton />
+        <TrendingItemSkeleton />
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/trending-item.tsx
+++ b/src/components/ui/trending-item.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+type Props = {
+  label: string;
+  count: number;
+};
+
+export const TrendingItem = ({ label, count }: Props) => {
+  return (
+    <Link
+      href={`/search?q=${encodeURIComponent(label)}`}
+      className="group/item"
+    >
+      <div className="group-hover/item:underline font-bold">{label}</div>
+      <div className="text-sm text-gray-400">{count} posts</div>
+    </Link>
+  );
+};
+
+export const TrendingItemSkeleton = () => {
+  return (
+    <div className="animate-pulse flex flex-col gap-1">
+      <div className="h-4 bg-gray-600 w-3/4 rounded" />
+      <div className="h-4 bg-gray-600 w-1/4 rounded" />
+    </div>
+  );
+};


### PR DESCRIPTION
Introduce a right-hand sidebar: SearchInput, TrendingArea and RecommendationArea are added and wired into the main layout. New components: search-input, trending-area (+item and skeleton), recommendation-area (+item and skeleton) — recommendation items include follow/unfollow state and skeleton placeholders. Input component updated with an onEnter prop and onKeyUp handler (so Enter can trigger searches) and a corrected password toggle logic. Also set NavMyProfile avatar Image to loading="eager" for faster display.

closes #14
closes #15 
closes #16 