### PR TITLE
Add: edit/search/tweet pages and UI components

### DIFF
--- a/src/app/(ui)/[slug]/edit/page.tsx
+++ b/src/app/(ui)/[slug]/edit/page.tsx
@@ -1,0 +1,62 @@
+import { Button } from "@/components/ui/button";
+import { GeneralHeader } from "@/components/ui/general-header";
+import { Input } from "@/components/ui/input";
+import { TextArea } from "@/components/ui/text-area";
+import { user } from "@/data/user";
+import { faCamera } from "@fortawesome/free-regular-svg-icons";
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Image from "next/image";
+
+export default function Page() {
+  return (
+    <div>
+      <GeneralHeader backHref={`/${user.slug}`}>
+        <div className="font-bold text-lg">Edit Profile</div>
+      </GeneralHeader>
+      <section className="border-b-2 border-b-gray-900">
+        <div className="flex justify-center items-center gap-4 bg-gray-500 h-28 relative">
+          {user.cover && (
+            <Image src={user.cover} alt="Cover" fill className="object-cover" />
+          )}
+          <div className="relative cursor-pointer bg-black/80  flex justify-center items-center size-12 rounded-full">
+            <FontAwesomeIcon icon={faCamera} className="size-6!" />
+          </div>
+          <div className="relative cursor-pointer bg-black/80  flex justify-center items-center size-12 rounded-full">
+            <FontAwesomeIcon icon={faXmark} className="size-6!" />
+          </div>
+        </div>
+        <div className="relative -mt-12 px-6">
+          <Image
+            src={user.avatar}
+            alt={user.name}
+            width={96}
+            height={96}
+            className="rounded-full"
+          />
+          <div className="-mt-24 size-24 flex justify-center items-center ">
+            <div className="relative cursor-pointer bg-black/80  flex justify-center items-center size-12 rounded-full">
+              <FontAwesomeIcon icon={faCamera} className="size-6!" />
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="p=6 flex flex-col gap-4">
+        <label>
+          <p className="text-lg text-gray-500 mb-2">Name</p>
+          <Input value={user.name} placeholder="Type your name" />
+        </label>
+        <label>
+          <p className="text-lg text-gray-500 mb-2">Bio</p>
+          <TextArea value={user.bio} placeholder="Type your bio" rows={4} />
+        </label>
+        <label>
+          <p className="text-lg text-gray-500 mb-2">Website</p>
+          <Input value={user.link} placeholder="Type your website" />
+        </label>
+
+        <Button label="Save Changes" size="lg" />
+      </section>
+    </div>
+  );
+}

--- a/src/app/(ui)/[slug]/page.tsx
+++ b/src/app/(ui)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { ProfileFeed } from "@/components/profile/profile-feed";
 import { Button } from "@/components/ui/button";
 import { GeneralHeader } from "@/components/ui/general-header";
 import { user } from "@/data/user";
@@ -62,6 +63,7 @@ export default function Page() {
           </div>
         </div>
       </section>
+      <ProfileFeed />
     </div>
   );
 }

--- a/src/app/(ui)/search/page.tsx
+++ b/src/app/(ui)/search/page.tsx
@@ -1,0 +1,27 @@
+import { TweetItem } from "@/components/tweet/tweet-item";
+import { GeneralHeader } from "@/components/ui/general-header";
+import { SearchInput } from "@/components/ui/search-input";
+import { tweets } from "@/data/tweet";
+//import { redirect } from "next/navigation";
+
+type Props = {
+  searchParams: {
+    q: string | undefined;
+  };
+};
+
+export default function Page({ searchParams }: Props) {
+  //if (!searchParams.q) redirect("/");
+  return (
+    <div>
+      <GeneralHeader backHref="/">
+        <SearchInput defaultValue={searchParams.q} />
+      </GeneralHeader>
+      <div className="border-t-2 border-gray-900">
+        {tweets.map((tweet) => (
+          <TweetItem key={tweet.id} tweet={tweet} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(ui)/tweet/[id]/page.tsx
+++ b/src/app/(ui)/tweet/[id]/page.tsx
@@ -1,0 +1,25 @@
+import { TweetItem } from "@/components/tweet/tweet-item";
+import { TweetPost } from "@/components/tweet/tweet-post";
+import { GeneralHeader } from "@/components/ui/general-header";
+import { tweets } from "@/data/tweet";
+
+export default function Page() {
+  return (
+    <div>
+      <GeneralHeader backHref="/">
+        <div className="font-bold text-lg">Back</div>
+      </GeneralHeader>
+      <div className="border-t-2 border-gray-900">
+        <TweetItem tweet={tweets[0]} />
+
+        <div className="border-y-8 border-gray-900">
+          <TweetPost/>
+        </div>
+
+        {tweets.map((tweet) => (
+          <TweetItem key={tweet.id} tweet={tweet} hideComments />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/profile-feed.tsx
+++ b/src/components/profile/profile-feed.tsx
@@ -1,11 +1,11 @@
 import { TweetItem } from "../tweet/tweet-item";
 import { tweets } from "@/data/tweet";
 
-export const HomeFeed = () => {
+export const ProfileFeed = () => {
   return (
     <div>
-      {tweets.map((item) => (
-        <TweetItem key={item.id} tweet={item} />
+      {tweets.map((tweet) => (
+        <TweetItem key={tweet.id} tweet={tweet} />
       ))}
     </div>
   );

--- a/src/components/tweet/tweet-item.tsx
+++ b/src/components/tweet/tweet-item.tsx
@@ -3,7 +3,10 @@
 import { Tweet } from "@/types/tweet";
 import { formatRelative } from "@/utils/format-relative";
 import { faComment, faHeart } from "@fortawesome/free-regular-svg-icons";
-import { faRetweet, faHeart as faHeartFilled } from "@fortawesome/free-solid-svg-icons";
+import {
+  faRetweet,
+  faHeart as faHeartFilled,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
 import Link from "next/link";
@@ -11,9 +14,10 @@ import { useState } from "react";
 
 type Props = {
   tweet: Tweet;
+  hideComments?: boolean;
 };
 
-export const TweetItem = ({ tweet }: Props) => {
+export const TweetItem = ({ tweet, hideComments = false }: Props) => {
   const [liked, setLiked] = useState(tweet.liked);
 
   const handleLikeButton = () => {
@@ -38,7 +42,9 @@ export const TweetItem = ({ tweet }: Props) => {
           <div className="font-bold text-lg">
             <Link href={`/${tweet.user.slug}`}>{tweet.user.name}</Link>
           </div>
-          <div className="text-xs text-gray-500">@{tweet.user.slug} - {formatRelative(tweet.dataPost)}</div>
+          <div className="text-xs text-gray-500">
+            @{tweet.user.slug} - {formatRelative(tweet.dataPost)}
+          </div>
         </div>
         <div className="py-4 text-lg">{tweet.body}</div>
         {tweet.image && (
@@ -53,14 +59,16 @@ export const TweetItem = ({ tweet }: Props) => {
           </div>
         )}
         <div className="flex mt-6 text-gray-500">
-          <div className="flex-1">
-            <Link href={`/tweet/${tweet.id}`}>
-              <div className="inline-flex items-center gap-2 cursor-pointer">
-                <FontAwesomeIcon icon={faComment} className="size-6!" />
-                <div className="text-lg">{tweet.commentsCount}</div>
-              </div>
-            </Link>
-          </div>
+          {!hideComments && (
+            <div className="flex-1">
+              <Link href={`/tweet/${tweet.id}`}>
+                <div className="inline-flex items-center gap-2 cursor-pointer">
+                  <FontAwesomeIcon icon={faComment} className="size-6!" />
+                  <div className="text-lg">{tweet.commentsCount}</div>
+                </div>
+              </Link>
+            </div>
+          )}
           <div className="flex-1">
             <div className="inline-flex items-center gap-2 cursor-pointer">
               <Link href={`/tweet/${tweet.id}`}>
@@ -72,8 +80,14 @@ export const TweetItem = ({ tweet }: Props) => {
             </div>
           </div>
           <div className="flex-1">
-            <div onClick={handleLikeButton} className={`inline-flex items-center gap-2 cursor-pointer ${liked ? "text-red-400" : ""}`}>
-              <FontAwesomeIcon icon={liked ? faHeartFilled : faHeart} className="size-6!" />
+            <div
+              onClick={handleLikeButton}
+              className={`inline-flex items-center gap-2 cursor-pointer ${liked ? "text-red-400" : ""}`}
+            >
+              <FontAwesomeIcon
+                icon={liked ? faHeartFilled : faHeart}
+                className="size-6!"
+              />
               <div className="text-lg">{tweet.likesCount}</div>
             </div>
           </div>

--- a/src/components/ui/text-area.tsx
+++ b/src/components/ui/text-area.tsx
@@ -1,0 +1,18 @@
+type Props = {
+  placeholder?: string;
+  rows: number;
+  value?: string;
+};
+
+export const TextArea = ({ placeholder, rows, value }: Props) => {
+  return (
+    <div className="has-focus:border-white flex items-center rounded-3xl border-2 border-gray-700">
+      <textarea
+        className="flex-1 outline-none bg-transparent h-full p-5 resize-none"
+        placeholder={placeholder}
+        rows={rows}
+        value={value}
+      />
+    </div>
+  );
+};

--- a/src/data/tweet.ts
+++ b/src/data/tweet.ts
@@ -1,12 +1,13 @@
 import { Tweet } from "@/types/tweet";
 import { user } from "./user";
 
-export const tweet: Tweet[] = [
+export const tweets: Tweet[] = [
   {
     id: 9,
     user: user,
     body: "Just finished setting up the new Y Network feed! 🚀 What do you guys think of the layout?",
-    image: "https://images.unsplash.com/photo-1614332287897-cdc485fa562d?q=80&w=2070&auto=format&fit=crop",
+    image:
+      "https://images.unsplash.com/photo-1614332287897-cdc485fa562d?q=80&w=2070&auto=format&fit=crop",
     likesCount: 523,
     commentsCount: 61,
     retweetsCount: 12,
@@ -18,7 +19,8 @@ export const tweet: Tweet[] = [
     id: 8,
     user: user,
     body: "Next.js 15+ and Tailwind v4 is such a powerful combination. Building fast and beautiful apps has never been easier.",
-    image: "https://images.unsplash.com/photo-1555066931-4365d14bab8c?q=80&w=2070&auto=format&fit=crop",
+    image:
+      "https://images.unsplash.com/photo-1555066931-4365d14bab8c?q=80&w=2070&auto=format&fit=crop",
     likesCount: 150,
     commentsCount: 20,
     retweetsCount: 5,
@@ -30,7 +32,8 @@ export const tweet: Tweet[] = [
     id: 7,
     user: user,
     body: "Coffee and code kind of day. ☕️💻 Crushing these features one by one!",
-    image: "https://images.unsplash.com/photo-1499750310107-5fef28a66643?q=80&w=2070&auto=format&fit=crop",
+    image:
+      "https://images.unsplash.com/photo-1499750310107-5fef28a66643?q=80&w=2070&auto=format&fit=crop",
     likesCount: 89,
     commentsCount: 12,
     retweetsCount: 2,
@@ -53,7 +56,8 @@ export const tweet: Tweet[] = [
     id: 5,
     user: user,
     body: "A clean workspace leads to a clean mind. 🧘‍♂️✨",
-    image: "https://images.unsplash.com/photo-1497215728101-856f4ea42174?q=80&w=2070&auto=format&fit=crop",
+    image:
+      "https://images.unsplash.com/photo-1497215728101-856f4ea42174?q=80&w=2070&auto=format&fit=crop",
     likesCount: 210,
     commentsCount: 15,
     retweetsCount: 8,
@@ -65,7 +69,8 @@ export const tweet: Tweet[] = [
     id: 4,
     user: user,
     body: "Throwback to when we first started the Y Network project. One year ago today!",
-    image: "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?q=80&w=2070&auto=format&fit=crop",
+    image:
+      "https://images.unsplash.com/photo-1517694712202-14dd9538aa97?q=80&w=2070&auto=format&fit=crop",
     likesCount: 1200,
     commentsCount: 45,
     retweetsCount: 300,
@@ -77,7 +82,8 @@ export const tweet: Tweet[] = [
     id: 3,
     user: user,
     body: "Can't believe it's been two years since I moved to this city. Best decision ever.",
-    image: "https://images.unsplash.com/photo-1498050108023-c5249f4df085?q=80&w=2070&auto=format&fit=crop",
+    image:
+      "https://images.unsplash.com/photo-1498050108023-c5249f4df085?q=80&w=2070&auto=format&fit=crop",
     likesCount: 450,
     commentsCount: 22,
     retweetsCount: 15,
@@ -89,7 +95,8 @@ export const tweet: Tweet[] = [
     id: 2,
     user: user,
     body: "Remember when 1080p was the cutting edge? 😅 Hello from 2016!",
-    image: "https://images.unsplash.com/photo-1550745165-9bc0b252726f?q=80&w=2070&auto=format&fit=crop",
+    image:
+      "https://images.unsplash.com/photo-1550745165-9bc0b252726f?q=80&w=2070&auto=format&fit=crop",
     likesCount: 3500,
     commentsCount: 150,
     retweetsCount: 800,


### PR DESCRIPTION
Add profile edit, search, and tweet detail pages; introduce ProfileFeed and TextArea components. Update HomeFeed to use renamed tweets array (data/tweet.ts) and reformat image strings. Improve TweetItem by adding hideComments prop, cleaning up imports/markup, and updating like button handling. Integrate ProfileFeed into profile page and wire up new UI pieces for profile editing and search results.

closes #26 
closes #27 
closes #28 
closes #29 
closes #30 